### PR TITLE
run `npm audit fix`

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -678,9 +678,9 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
-			"integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+			"integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -693,9 +693,9 @@
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.1.tgz",
-			"integrity": "sha512-RI17tsD2frtDu/3dmI7QRrD4bedNKPM08ziRYaC5AhkGrzIAJelm9kJU1TznK+apx6V+cqRz8tfpEeG3oIyjxw==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+			"integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -703,9 +703,9 @@
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
-			"integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+			"integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -777,13 +777,16 @@
 			"license": "MIT"
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.25.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.25.0.tgz",
-			"integrity": "sha512-iWhsUS8Wgxz9AXNfvfOPFSW4VfMXdVhp1hjkZVhXCrpgh/aLcc45rX6MPu+tIVUWDw0HfNwth7O28M1xDxNf9w==",
+			"version": "9.33.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.33.0.tgz",
+			"integrity": "sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
 			}
 		},
 		"node_modules/@eslint/object-schema": {
@@ -797,13 +800,13 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
-			"integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+			"integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^0.13.0",
+				"@eslint/core": "^0.15.2",
 				"levn": "^0.4.1"
 			},
 			"engines": {
@@ -1237,6 +1240,12 @@
 				"win32"
 			]
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+			"integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+			"license": "MIT"
+		},
 		"node_modules/@sveltejs/acorn-typescript": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
@@ -1259,11 +1268,12 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.21.5",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.21.5.tgz",
-			"integrity": "sha512-P5m7yZtvD1Kx/Z6JcjgJtdMqef/tCGMDrd9B9S2q8j+FMnkeKTMxW1nidnjVzk4HEDRGf4IlBI94/niy6t3hLA==",
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.28.0.tgz",
+			"integrity": "sha512-qrhygwHV5r6JrvCw4gwNqqxYGDi5YbajocxfKgFXmSFpFo8wQobUvsM0OfakN4h+0LEmXtqHRrC6BcyAkOwyoQ==",
 			"license": "MIT",
 			"dependencies": {
+				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
 				"@types/cookie": "^0.6.0",
 				"acorn": "^8.14.1",
@@ -1275,8 +1285,7 @@
 				"mrmime": "^2.0.0",
 				"sade": "^1.8.1",
 				"set-cookie-parser": "^2.6.0",
-				"sirv": "^3.0.0",
-				"vitefu": "^1.0.6"
+				"sirv": "^3.0.0"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
@@ -1285,9 +1294,9 @@
 				"node": ">=18.13"
 			},
 			"peerDependencies": {
-				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0",
+				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
-				"vite": "^5.0.3 || ^6.0.0"
+				"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
@@ -1794,9 +1803,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.14.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -2304,20 +2313,20 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.25.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.25.0.tgz",
-			"integrity": "sha512-MsBdObhM4cEwkzCiraDv7A6txFXEqtNXOb877TsSp2FCkBNl8JfVQrmiuDqC1IkejT6JLPzYBXx/xAiYhyzgGA==",
+			"version": "9.33.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.33.0.tgz",
+			"integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.20.0",
-				"@eslint/config-helpers": "^0.2.1",
-				"@eslint/core": "^0.13.0",
+				"@eslint/config-array": "^0.21.0",
+				"@eslint/config-helpers": "^0.3.1",
+				"@eslint/core": "^0.15.2",
 				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.25.0",
-				"@eslint/plugin-kit": "^0.2.8",
+				"@eslint/js": "9.33.0",
+				"@eslint/plugin-kit": "^0.3.5",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
@@ -2328,9 +2337,9 @@
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^8.3.0",
-				"eslint-visitor-keys": "^4.2.0",
-				"espree": "^10.3.0",
+				"eslint-scope": "^8.4.0",
+				"eslint-visitor-keys": "^4.2.1",
+				"espree": "^10.4.0",
 				"esquery": "^1.5.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -2424,9 +2433,9 @@
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
-			"integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -2441,9 +2450,9 @@
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -2501,15 +2510,15 @@
 			"license": "MIT"
 		},
 		"node_modules/espree": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-			"integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.14.0",
+				"acorn": "^8.15.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^4.2.0"
+				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"


### PR DESCRIPTION
I ran `npm audit fix`. This quick PR eliminates [this vulnerability](https://github.com/advisories/GHSA-xffm-g5w8-qvg7) in `@eslint/plugin-kit`, which affects parsing ESLint config comments (even though I've never used such comments in the first place).