### PR TITLE
Remove model_module/.nvimlog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /frontend/.svelte-kit/*
 
 # neovim
-.nvimlog
+**/.nvimlog
 
 # Python
 **/__pycache__/


### PR DESCRIPTION
A sort of spiritual successor to [this previous pull request](https://github.com/SGIARK/arkos/pull/40). There was a spurious `model_module/.nvimlog`, so I've deleted it, and I've also updated the gitignore so that *no* nvimlog file is ever tracked by git again.