### PR TITLE
Retire plan pins when their run ends

### DIFF
--- a/frontend/lookingglass.jsx
+++ b/frontend/lookingglass.jsx
@@ -418,21 +418,6 @@ function SessionDetail({ sessionId, project, onBack, onError, onPulse, onOpenFil
   // from the server and is what survives a reload, but it was read before the
   // approval, so the pinned card would not appear until then without this.
   const [approvedHere, setApprovedHere] = useState(null);
-  /* Dismissing a finished plan clears it from THIS surface and nothing else:
-     the row is a permanent fact and is never deleted. Kept per browser rather
-     than in memory, because a reload resurrecting a plan you dismissed reads as
-     the dismissal not having worked. */
-  const dismissKey = `ark-plan-dismissed-${sessionId}`;
-  const [dismissedVersion, setDismissedVersion] = useState(() => {
-    const stored = Number(localStorage.getItem(dismissKey));
-    return Number.isFinite(stored) && stored > 0 ? stored : 0;
-  });
-  const dismissPlan = (version) => {
-    localStorage.setItem(dismissKey, String(version || 1));
-    setDismissedVersion(version || 1);
-    setApprovedHere(null);
-    setResumeNote("");
-  };
 
   /* Renaming the project from its own window. Keyed off the SNAPSHOT's ids
      rather than the grid's navigation state, so it works in a window opened
@@ -497,8 +482,8 @@ function SessionDetail({ sessionId, project, onBack, onError, onPulse, onOpenFil
   const planCard = openPlan;
   /* Everything below reads the server's `plan` — its `answer` is what became of
      it — with one local override for the approval made in THIS window, which the
-     snapshot was read before. Dismissing hides whatever version was dismissed. */
-  const serverPlan = session.plan && session.plan.version > dismissedVersion ? session.plan : null;
+     snapshot was read before. */
+  const serverPlan = session.plan;
   const approvedPlan = approvedHere || (serverPlan && serverPlan.answer === "approve" ? serverPlan : null);
   const abandonedPlan = serverPlan && serverPlan.answer === "decline" ? serverPlan : null;
 
@@ -510,9 +495,9 @@ function SessionDetail({ sessionId, project, onBack, onError, onPulse, onOpenFil
      reload and right in a second tab. */
   const held = session.status === "idle" && unattended;
   const cancelled = !!approvedPlan && session.status === "cancelled";
-  // The pin outlives the run: an approved plan that finished still says where
-  // it was saved. It goes only when the plan is dismissed.
-  const showPin = !!approvedPlan;
+  // The lifecycle is the only authority over the pin: terminal sessions hand
+  // back to attended, while a stopped run stays idle and unattended.
+  const showPin = !!approvedPlan && unattended && ["running", "awaiting_approval", "idle"].includes(session.status);
   const stopStep = session.hops_used || 1;
   /* ▶ is offered when nothing is pending on the human and nothing is in flight:
      an idle session, a finished one, a dismissed plan, or a cancelled run
@@ -816,9 +801,6 @@ function SessionDetail({ sessionId, project, onBack, onError, onPulse, onOpenFil
                 >
                   draft a continuation
                 </button>
-                <button className="link mute" onClick={() => dismissPlan(approvedPlan.version)}>
-                  dismiss
-                </button>
               </div>
             )}
 
@@ -837,9 +819,6 @@ function SessionDetail({ sessionId, project, onBack, onError, onPulse, onOpenFil
                   }}
                 >
                   draft again
-                </button>
-                <button className="link mute" onClick={() => dismissPlan(abandonedPlan.version)}>
-                  dismiss
                 </button>
               </div>
             )}
@@ -1280,4 +1259,3 @@ function BrowserCanvas({ url, label }) {
     </div>
   );
 }
-

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -642,8 +642,9 @@ kbd {
 .lg-detail { display: flex; flex-direction: column; flex: 1; min-height: 0; }
 .lg-body { flex: 1; display: grid; grid-template-columns: 1fr 300px; grid-template-rows: 1fr; min-height: 0; overflow: hidden; }
 .stream-wrap { min-height: 0; min-width: 0; display: flex; flex-direction: column; border-right: 1px solid var(--line); }
-.stream { flex: 1; min-width: 0; overflow-y: auto; padding: 26px 40px 20px; display: flex; flex-direction: column; gap: 16px; }
+.stream { flex: 1; min-width: 0; overflow-x: hidden; overflow-y: auto; padding: 26px 40px 20px; display: flex; flex-direction: column; gap: 16px; }
 .ev-block { max-width: 760px; }
+.msg .bubble, .ev-assist p, .ev-tool .args, .ev-gated .args, .ev-result pre, .ev-user .said, .ev-reasoning pre { overflow-wrap: anywhere; }
 .ev-assist { font-size: 13px; line-height: 1.7; color: var(--ink-soft); }
 .ev-assist .who { display: block; font-size: 9.5px; letter-spacing: .16em; text-transform: uppercase; color: var(--ink-mute); margin-bottom: 6px; }
 .ev-assist p { margin: 0; }
@@ -1317,4 +1318,3 @@ kbd {
 .card.approval .plan-brief .done { margin-bottom: 7px; color: var(--ink); }
 .card.approval .plan-brief ol { margin: 0; padding-left: 18px; }
 .card.approval .plan-brief .missing { margin-top: 9px; font-size: 10.5px; color: var(--work); }
-


### PR DESCRIPTION
An approved plan remained pinned after its unattended run had completed, failed, or been cancelled. A browser-local dismissal key was used to hide the stale row, leaving lifecycle state and local storage as competing authorities. This PR makes the session lifecycle authoritative. The pin is shown only while an approved plan belongs to a running, approval-waiting, or held unattended session; terminal runs retire it automatically. Cancelled and declined plan faces remain available with their existing follow-up actions, but manual dismiss controls and stored overrides are removed. Transcript overflow is tightened at the same time: horizontal growth is clipped, and one shared rule allows long user messages, model prose, tool arguments, tool results, and reasoning text to wrap anywhere. The change is limited to the session view and stylesheet.